### PR TITLE
記事のレイアウトをzennっぽくなるように修正

### DIFF
--- a/app/components/navigation/Navigation.tsx
+++ b/app/components/navigation/Navigation.tsx
@@ -12,7 +12,7 @@ type NavigationProps = {
 const Navigation: React.FC<NavigationProps> = ({ currentUser }) => {
   return (
     <header className="shadow-lg shadow-gray-100">
-      <div className="container mx-auto flex max-w-screen-sm items-center justify-between px-1 py-5">
+      <div className="bg-white mx-auto flex items-center justify-between px-20 py-5">
         <Link href="/home" className="cursor-pointer text-xl font-bold">
           offline
         </Link>

--- a/app/documents/phase1/github/first-step/page.mdx
+++ b/app/documents/phase1/github/first-step/page.mdx
@@ -1,9 +1,9 @@
 {/* gitについて */}
 {/* /documents/phase1/github/first-step */}
 
-<main className="mx-auto max-w-screen-xl flex-1 px-1">
-<div class="bg-white flex justify-center items-center min-h-screen">
-  <div class="max-w-screen-md w-full px-4">
+<main>
+  <div className="bg-white justify-center items-center min-h-screen w-full rounded-[10px]">
+    <div className="container mx-auto max-w-screen-xl flex-1 px-1 my-7 view-block">
 ## Phase1 github
 {/* 35文字で改行される */}
 
@@ -429,8 +429,6 @@ erorrも出ずに成功したら、無事グローバルの方に
 />
 リモートリポジトリのコミットを、ローカルリポジトリに取り込む
 {/* TODO 画像が必要 */}
-
 </div>
-
 </div>
 </main>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,22 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  background-color: #edf2f6; /* Zenn風の背景色 */
+  color: #333;
+}
+
+main {
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.view-block {
+  max-width: 1000px; /* Zenn のような幅 */
+  width: 950px;
+  background-color: #ffffff; /* 記事部分の背景を白に */
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* 影をつけて立体感を出す */
+  border-radius: 10px; /* 角を丸くする */
+  padding: 30px;
+}


### PR DESCRIPTION
# やったこと
- zennっぽくなるようにレイアウトを修正
# やってないこと
- レイアウトのコンポーネント化 
　props化してもっと見やすくできそうなため
- スタイルの当て方がもっと改善できそう,,,だが一旦スルー
# 関連記事
- 関連issue
- https://github.com/come3300/jibc-learning-app/issues/24